### PR TITLE
fix(Makefile): remove useless lint in PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: app-composer-validate app-cs-check app-cs-fix app-install app-lint app-lint-composer app-lint-yaml app-security-check \
-app-static-analysis app-test app-test-with-code-coverage ci
+.PHONY: app-composer-validate app-cs-check app-cs-fix app-install app-security-check app-static-analysis app-test \
+app-test-with-code-coverage ci
 
 default: help
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/sonata/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I delete useless lint into Makefile.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
- Remove useless lint into Makefile

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove useless lint into Makefile

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the Makefile

## Subject

<!-- Describe your Pull Request content here -->
I cleaned up the Makefile about lint composer and lint yaml