### PR TITLE
fix(config): Fix configuration for PHP-CS-Fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,25 +22,27 @@ return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
-        'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
-        'array_syntax' => array('syntax' => 'short'),
-        'blank_line_after_namespace' => true,
-        'header_comment' => array('header' => $header),
-        'lowercase_constants' => true,
-        'lowercase_keywords' => true,
-        'method_separation' => true,
-        'no_closing_tag' => true,
-        'no_extra_consecutive_blank_lines' => [
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+        'binary_operator_spaces' => [
+            'align_double_arrow' => true,
+            'align_equals'       => true
+        ],
+        'class_attributes_separation' => true,
+        'header_comment' => [
+            'header' => $header
+        ],
+        'linebreak_after_opening_tag' => true,
+        'no_extra_blank_lines' => [
             'tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']
         ],
         'no_short_echo_tag' => true,
-        'no_useless_else' => true,
+        'no_useless_else'   => true,
         'no_useless_return' => true,
-        'ordered_imports' => true,
+        'ordered_imports'   => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
-        'semicolon_after_instruction' => true,
-        'visibility_required' => true,
     ])
     ->setUsingCache(true)
     ->setFinder(

--- a/src/TestHelpers/Admin/AdminTestCase.php
+++ b/src/TestHelpers/Admin/AdminTestCase.php
@@ -107,6 +107,7 @@ abstract class AdminTestCase extends \PHPUnit\Framework\TestCase
      * @var string
      */
     protected $dummyAdminId    = 'sonata.admin';
+
     protected $dummyController = 'SonataAdminBundle:CRUD';
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/sonata/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a backwards compatible patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #29

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fixed PHP-CS-Fixer configuration

```

## Subject

Updates the `.php_cs` file. Many rules were redundant due to `@Symfony` or misconfigured.

The most relevant changes:

- `method_separation` was deprecated and is replaced by `class_attributes_separation`. The new configuration of this value should be discussed. (It caused the modification in `src/TestHelpers/Admin/AdminTestCase.php`.)
- `no_extra_consecutive_blank_lines` was deprecated and is replaced by `no_extra_blank_lines`.
- `phpdoc_add_missing_param_annotation` was misconfigured. The new configuration of this value should be discussed.
