### PR TITLE
Remove deprecation about configuration tree builder without a root node

### DIFF
--- a/CHANGELOG-0.0.md
+++ b/CHANGELOG-0.0.md
@@ -14,3 +14,4 @@ after the #.
   * Added (optional) replacement for "Add block" button, showing blocks in a categorized popup
   * Fixed PHP-CS-Fixer config
   * Added integration of a liipMonitor dashboard
+  * Remove deprecation about configuration tree builder without a root node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ master
 * Enable strict typing
 * Add Coveralls Tool for TravisCI
 * Add badges in the README
+* Remove deprecation about configuration tree builder without a root node

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,8 +28,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('sonata_helpers');
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder();
+            $rootNode    = $treeBuilder->root('sonata_helpers');
+        } else {
+            $treeBuilder = new TreeBuilder('sonata_helpers');
+            $rootNode    = $treeBuilder->getRootNode();
+        }
 
         $rootNode
             ->children()

--- a/tests/MockBuilderTrait.php
+++ b/tests/MockBuilderTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\HelpersBundle\Tests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Sonata\HelpersBundle\Tests\Common\TranslationTestHelper;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -26,7 +27,7 @@ trait MockBuilderTrait
     /**
      * Create TranslatorInterfaceMock and add a callback method to it.
      *
-     * @return TranslatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return TranslatorInterface|MockObject
      */
     protected function mockTranslator()
     {


### PR DESCRIPTION
I am targeting this branch, because this is the only one.

## Changelog

```markdown
### Fixed
Remove deprecation about configuration tree builder without a root node
```

related to https://github.com/symfony/config/blob/a17a2aea43950ce83a0603ed301bac362eb86870/Definition/Builder/TreeBuilder.php#L30