### PR TITLE
chore(dependencies): upgraded phpstan banned code and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 .php_cs.cache
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,13 @@ matrix:
   fast_finish: true
   include:
     - php: '7.4'
-      env: SYMFONY=3.4.*
-    - php: '7.4'
       env: SYMFONY=^4.4
     - php: '7.4'
       env: SYMFONY_DEPRECATIONS_HELPER=0
     - php: '7.3'
-      env: SYMFONY=3.4.*
-    - php: '7.3'
       env: SYMFONY=^4.4
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
-    - php: '7.2'
-      env: SYMFONY=3.4.*
     - php: '7.2'
       env: SYMFONY=^4.4
     - php: '7.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ master
 * CI: add php version 7.4 at nightly
 * Upgrade symfony/framework-bundle version to fix security issue
 * Adapted ImmutableTabsType and its test class to new Sonata form component (fixed namespace and inheritance)
+* Upgraded ekino/phpstan-banned-code to 0.3 and upgraded its dependencies
 
 v0.0.1
 ------

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,17 @@
     "sonata-project/doctrine-orm-admin-bundle": "^3.0",
     "sonata-project/media-bundle": "^3.0",
     "sonata-project/page-bundle": "^3.11",
-    "symfony/framework-bundle": "^3.4 || ^4.4"
+    "symfony/framework-bundle": "^4.4"
   },
   "require-dev": {
-    "ekino/phpstan-banned-code": "^0.2",
+    "ekino/phpstan-banned-code": "^0.3",
     "friendsofphp/php-cs-fixer": "^2.16",
-    "phpstan/phpstan-phpunit": "^0.11",
+    "localheinz/composer-normalize": "^1.3",
+    "phpstan/phpstan-phpunit": "^0.12",
     "phpunit/phpunit": "^7.2",
     "sensiolabs/security-checker": "^5.0",
-    "symfony/phpunit-bridge": "^5.0.3"
+    "symfony/phpunit-bridge": "^5.0.3",
+    "symfony/var-dumper": "^4.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/Controller/PageAdminController.php
+++ b/src/Controller/PageAdminController.php
@@ -90,7 +90,6 @@ class PageAdminController extends BasePageAdminController
         $blockServices = $this->blockServiceManager->getServicesByContext('sonata_page_bundle', false);
 
         // Filter service using the template configuration
-        /** @var Page $page */
         if ($page = $block->getPage()) {
             $template  = $this->templateManager->get($page->getTemplateCode());
             $container = $template->getContainer($block->getSetting('code'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/sonata/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because ekino/phpstan-banned-code needed to be upgraded.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed

Following dependencies : 
ekino/phpstan-banned-code
localheinz/composer-normalize
phpstan/phpstan-phpunit
symfony/phpunit-bridge
symfony/var-dumper
```