### PR TITLE
Fix deprecated function (replace AbstractAdminBlockService by Abstrac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ master
 * Switch to the new security checker
 * Migrate from Travis to GitHub Actions
 * Fix deprecated PHP-CS rules
+* Fix deprecations triggered by SonataBlockBundle
 
 v0.2.0
 ------

--- a/src/Block/Dashboard/MonitorBlockService.php
+++ b/src/Block/Dashboard/MonitorBlockService.php
@@ -13,17 +13,17 @@ namespace Sonata\HelpersBundle\Block\Dashboard;
 
 use Liip\MonitorBundle\Helper\PathHelper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * Class MonitorBlockService.
  *
  * @author Quentin Belot <quentin.belot@ekino.com>
  */
-class MonitorBlockService extends AbstractAdminBlockService
+class MonitorBlockService extends AbstractBlockService
 {
     /**
      * @var PathHelper
@@ -39,13 +39,11 @@ class MonitorBlockService extends AbstractAdminBlockService
      * MonitorBlockService constructor.
      */
     public function __construct(
-        string $name,
-        EngineInterface $templating,
+        Environment $templating,
         PathHelper $pathHelper,
         string $liipMonitorDefaultGroup
     ) {
-        parent::__construct($name, $templating);
-
+        parent::__construct($templating);
         $this->pathHelper              = $pathHelper;
         $this->liipMonitorDefaultGroup = $liipMonitorDefaultGroup;
     }

--- a/tests/Block/Dashboard/MonitorBlockServiceTest.php
+++ b/tests/Block/Dashboard/MonitorBlockServiceTest.php
@@ -14,10 +14,10 @@ namespace Sonata\HelpersBundle\Tests\Block\Dashboard;
 use Liip\MonitorBundle\Helper\PathHelper;
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Block\BlockContext;
-use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\HelpersBundle\Block\Dashboard\MonitorBlockService;
 use Sonata\PageBundle\Entity\BaseBlock;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * Class MonitorBlockServiceTest.
@@ -27,25 +27,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class MonitorBlockServiceTest extends TestCase
 {
     /**
-     * Test Get Name.
-     */
-    public function testGetName(): void
-    {
-        $pathHelper = $this->createMock(PathHelper::class);
-        $templating = new FakeTemplating();
-        $block      = new MonitorBlockService(MonitorBlockService::class, $templating, $pathHelper, 'defaultGroup');
-
-        $this->assertSame(MonitorBlockService::class, $block->getName());
-    }
-
-    /**
      * Test Execute.
      */
     public function testExecute(): void
     {
         $pathHelper     = $this->createMock(PathHelper::class);
-        $templating     = new FakeTemplating();
-        $service        = new MonitorBlockService(MonitorBlockService::class, $templating, $pathHelper, 'defaultGroup');
+        $templating     = $this->createMock(Environment::class);
+        $service        = new MonitorBlockService($templating, $pathHelper, 'defaultGroup');
         $block          = new Block();
         $optionResolver = new OptionsResolver();
 


### PR DESCRIPTION
…tBlockService)

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/sonata/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I removed deprecated function.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
